### PR TITLE
feat: Add HaveToPay widget to dashboard

### DIFF
--- a/src/controllers/dashboard.php
+++ b/src/controllers/dashboard.php
@@ -99,6 +99,9 @@ $stmt = $pdo->prepare("SELECT * FROM users WHERE id = ?");
 $stmt->execute([$userId]);
 $user = $stmt->fetch(PDO::FETCH_ASSOC);
 
+// Load HaveToPay widget data
+require_once __DIR__.'/widgets/havetopay_widget.php';
+
 // 8) Template rendern
 require_once __DIR__.'/../../templates/dashboard.php';
 ?>

--- a/src/controllers/widgets/havetopay_widget.php
+++ b/src/controllers/widgets/havetopay_widget.php
@@ -1,0 +1,66 @@
+<?php
+
+// 1. Ensure the user is logged in
+require_once __DIR__ . '/../../lib/auth.php';
+requireLogin();
+
+// 2. Get the current userId from the session
+$userId = $_SESSION['user_id'];
+
+// 3. Include the database connection
+require_once __DIR__ . '/../../lib/db.php';
+
+// 4. Initialize variables
+$widgetTotalOwed = 0;
+$widgetTotalOwing = 0;
+$widgetNetBalance = 0;
+
+try {
+    // 5. Fetch the total amount others owe the current user
+    $stmtOwed = $pdo->prepare("
+        SELECT SUM(ep.share_amount) AS total_owed
+        FROM expenses e
+        JOIN expense_participants ep ON e.id = ep.expense_id
+        WHERE e.payer_id = :user_id 
+        AND ep.user_id != :user_id 
+        AND ep.is_settled = 0
+    ");
+    $stmtOwed->bindParam(':user_id', $userId, PDO::PARAM_INT);
+    $stmtOwed->execute();
+    $resultOwed = $stmtOwed->fetch(PDO::FETCH_ASSOC);
+    if ($resultOwed && $resultOwed['total_owed']) {
+        $widgetTotalOwed = (float)$resultOwed['total_owed'];
+    }
+
+    // 6. Fetch the total amount the current user owes others
+    $stmtOwing = $pdo->prepare("
+        SELECT SUM(ep.share_amount) AS total_owing
+        FROM expenses e
+        JOIN expense_participants ep ON e.id = ep.expense_id
+        WHERE ep.user_id = :user_id 
+        AND e.payer_id != :user_id 
+        AND ep.is_settled = 0
+    ");
+    $stmtOwing->bindParam(':user_id', $userId, PDO::PARAM_INT);
+    $stmtOwing->execute();
+    $resultOwing = $stmtOwing->fetch(PDO::FETCH_ASSOC);
+    if ($resultOwing && $resultOwing['total_owing']) {
+        $widgetTotalOwing = (float)$resultOwing['total_owing'];
+    }
+
+    // 7. Calculate the net balance
+    $widgetNetBalance = $widgetTotalOwed - $widgetTotalOwing;
+
+} catch (PDOException $e) {
+    // 9. Include error handling and log any errors.
+    // If an error occurs, set default values (0) for the variables.
+    error_log("Error in havetopay_widget.php: " . $e->getMessage());
+    $widgetTotalOwed = 0;
+    $widgetTotalOwing = 0;
+    $widgetNetBalance = 0;
+}
+
+// 8. The script should make these variables available for inclusion in another PHP script.
+// This is implicitly done as the script will be included, and variables will be in scope.
+
+?>

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -255,6 +255,9 @@
         });
       </script>
 
+      <!-- HaveToPay Widget -->
+      <?php include __DIR__.'/widgets/havetopay_widget.php'; ?>
+
       <!-- Dokumente Widget -->
       <article class="bg-white rounded-2xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-6 flex flex-col">
         <a href="profile.php?tab=documents" class="group inline-flex items-center mb-4">

--- a/templates/widgets/havetopay_widget.php
+++ b/templates/widgets/havetopay_widget.php
@@ -1,0 +1,47 @@
+<?php
+// Ensure variables are set, providing defaults if not (though they should be set by the controller)
+$widgetTotalOwed = $widgetTotalOwed ?? 0.00;
+$widgetTotalOwing = $widgetTotalOwing ?? 0.00;
+$widgetNetBalance = $widgetNetBalance ?? 0.00;
+?>
+<article class="bg-white rounded-2xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-6 flex flex-col">
+    <div class="flex justify-between items-start mb-4">
+        <a href="havetopay.php" class="group inline-flex items-center">
+            <h2 class="text-lg font-semibold mr-1">HaveToPay Overview</h2>
+            <svg class="w-4 h-4 fill-current text-gray-400 group-hover:text-gray-600 transition-colors" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+            </svg>
+        </a>
+        <a href="havetopay_add.php" title="Add Expense" class="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold px-3 py-1.5 rounded-lg shadow-sm flex items-center text-sm">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-1" viewBox="0 0 20 20" fill="currentColor">
+                <path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd" />
+            </svg>
+            Add Expense
+        </a>
+    </div>
+
+    <div class="space-y-2 text-sm mb-4">
+        <p>
+            <span class="font-medium">You are owed:</span>
+            <span class="text-green-600 font-semibold">
+                €<?php echo htmlspecialchars(number_format($widgetTotalOwed, 2, ',', '.')); ?>
+            </span>
+        </p>
+        <p>
+            <span class="font-medium">You owe:</span>
+            <span class="text-red-600 font-semibold">
+                €<?php echo htmlspecialchars(number_format($widgetTotalOwing, 2, ',', '.')); ?>
+            </span>
+        </p>
+        <hr class="my-1">
+        <p class="text-base">
+            <span class="font-semibold">Net Balance:</span>
+            <span class="<?php echo ($widgetNetBalance >= 0) ? 'text-green-600' : 'text-red-600'; ?> font-bold">
+                €<?php echo htmlspecialchars(number_format($widgetNetBalance, 2, ',', '.')); ?>
+            </span>
+        </p>
+    </div>
+
+    <!-- The "+" button is placed at the top-right for better visibility and consistency with potential other widgets -->
+    <!-- If a different placement is preferred, it can be moved. -->
+</article>


### PR DESCRIPTION
Adds a HaveToPay overview widget to the main dashboard.

The widget displays:
- Total amount owed to you.
- Total amount you owe to others.
- The net balance.
- A quick link/button to add a new expense.

This involved:
- Creating a new controller (`src/controllers/widgets/havetopay_widget.php`) to fetch the necessary summary data.
- Creating a new template (`templates/widgets/havetopay_widget.php`) for the widget's UI.
- Integrating the data controller into `src/controllers/dashboard.php`.
- Integrating the widget template into `templates/dashboard.php` for display.