### PR TITLE
refactor: Enhance HaveToPay UI and widget placement

### DIFF
--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -255,9 +255,6 @@
         });
       </script>
 
-      <!-- HaveToPay Widget -->
-      <?php include __DIR__.'/widgets/havetopay_widget.php'; ?>
-
       <!-- Dokumente Widget -->
       <article class="bg-white rounded-2xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-6 flex flex-col">
         <a href="profile.php?tab=documents" class="group inline-flex items-center mb-4">
@@ -325,6 +322,9 @@
           <?= $name ?>-Widget
         </article>
       <?php endforeach; ?>
+
+      <!-- HaveToPay Widget -->
+      <?php include __DIR__.'/widgets/havetopay_widget.php'; ?>
     </div><!-- /grid -->
   </main>
   

--- a/templates/havetopay.php
+++ b/templates/havetopay.php
@@ -6,72 +6,6 @@
     <title>HaveToPay | PrivateVault</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
-    <style>
-        :root {
-            --primary-color: #4F46E5;
-            --success-color: #10B981;
-            --danger-color: #EF4444;
-        }
-        
-        .modern-card {
-            background: white;
-            border-radius: 16px;
-            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-            transition: all 0.3s ease;
-        }
-        
-        .modern-card:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
-        }
-        
-        .gradient-primary {
-            background: linear-gradient(135deg, var(--primary-color), #3730A3);
-        }
-        
-        .gradient-success {
-            background: linear-gradient(135deg, var(--success-color), #059669);
-        }
-        
-        .gradient-danger {
-            background: linear-gradient(135deg, var(--danger-color), #B91C1C);
-        }
-        
-        .btn-modern {
-            border-radius: 12px;
-            padding: 12px 24px;
-            font-weight: 600;
-            transition: all 0.3s ease;
-        }
-        
-        .btn-modern:hover {
-            transform: translateY(-2px);
-        }
-        
-        .balance-card {
-            animation: fadeIn 0.6s ease-out;
-        }
-        
-        @keyframes fadeIn {
-            from { opacity: 0; transform: translateY(20px); }
-            to { opacity: 1; transform: translateY(0); }
-        }
-        
-        /* Mobile adjustments */
-        @media (max-width: 768px) {
-            body {
-                padding-top: 4rem !important;
-            }
-        }
-        
-        /* Desktop adjustments */
-        @media (min-width: 769px) {
-            .main-content {
-                margin-left: 16rem;
-                width: calc(100% - 16rem);
-            }
-        }
-    </style>
 </head>
 <body class="bg-gray-50">
     <div class="main-content p-6">
@@ -96,30 +30,30 @@
                 <i class="fas fa-wallet mr-3 text-indigo-600"></i>HaveToPay
             </h1>
             <div class="flex gap-3">
-                <a href="havetopay_add.php" class="btn-modern bg-indigo-600 text-white hover:bg-indigo-700 flex items-center">
+                <a href="havetopay_add.php" class="bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded-lg shadow-sm flex items-center">
                     <i class="fas fa-plus mr-2"></i>Add Expense
                 </a>
-                <a href="index.php" class="btn-modern bg-gray-200 text-gray-700 hover:bg-gray-300 flex items-center">
+                <a href="index.php" class="bg-gray-200 hover:bg-gray-300 text-gray-700 font-semibold py-2 px-4 rounded-lg shadow-sm flex items-center">
                     <i class="fas fa-home mr-2"></i>Dashboard
                 </a>
             </div>
         </div>
 
         <!-- Balance Summary Card -->
-        <div class="modern-card balance-card mb-8">
-            <div class="gradient-primary text-white p-6 rounded-t-2xl">
-                <h2 class="text-xl font-bold">Your Balance Summary</h2>
+        <div class="bg-white shadow-md rounded-lg mb-8">
+            <div class="p-4 border-b border-gray-200">
+                <h2 class="text-xl font-semibold text-gray-700">Your Balance Summary</h2>
             </div>
             <div class="p-6">
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 text-center">
                     <div>
                         <div class="text-gray-600 text-sm font-medium">You are owed</div>
-                        <div class="text-3xl font-bold text-green-600 mt-2"><?php echo number_format($totalOwed, 2); ?> €</div>
+                        <div class="text-2xl font-bold text-green-600 mt-1"><?php echo number_format($totalOwed, 2); ?> €</div>
                     </div>
                     
                     <div>
                         <div class="text-gray-600 text-sm font-medium">Your net balance</div>
-                        <div class="text-3xl font-bold <?php echo $netBalance >= 0 ? 'text-green-600' : 'text-red-600'; ?> mt-2">
+                        <div class="text-2xl font-bold <?php echo $netBalance >= 0 ? 'text-green-600' : 'text-red-600'; ?> mt-1">
                             <?php echo number_format($netBalance, 2); ?> €
                         </div>
                         <div class="mt-2">
@@ -132,7 +66,7 @@
                     
                     <div>
                         <div class="text-gray-600 text-sm font-medium">You owe</div>
-                        <div class="text-3xl font-bold text-red-600 mt-2"><?php echo number_format($totalOwing, 2); ?> €</div>
+                        <div class="text-2xl font-bold text-red-600 mt-1"><?php echo number_format($totalOwing, 2); ?> €</div>
                     </div>
                 </div>
             </div>
@@ -141,10 +75,10 @@
         <!-- Main Content Grid -->
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
             <!-- People who owe me -->
-            <div class="modern-card">
-                <div class="gradient-success text-white p-4 rounded-t-2xl flex justify-between items-center">
-                    <h3 class="font-bold">People Who Owe You</h3>
-                    <span class="bg-white text-green-600 px-3 py-1 rounded-full text-sm font-medium">
+            <div class="bg-white shadow-md rounded-lg">
+                <div class="p-4 border-b border-gray-200 flex justify-between items-center">
+                    <h3 class="text-lg font-semibold text-gray-700">People Who Owe You</h3>
+                    <span class="bg-green-100 text-green-700 px-3 py-1 rounded-full text-xs font-semibold">
                         <?php echo count($balances['others_owe']); ?> people
                     </span>
                 </div>
@@ -157,9 +91,9 @@
                     <?php else: ?>
                         <div class="space-y-3">
                             <?php foreach ($balances['others_owe'] as $balance): ?>
-                            <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
+                            <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100">
                                 <div class="flex items-center">
-                                    <div class="w-10 h-10 bg-indigo-600 text-white rounded-full flex items-center justify-center font-semibold mr-3">
+                                    <div class="w-10 h-10 bg-slate-200 text-slate-600 rounded-full flex items-center justify-center font-semibold mr-3">
                                         <?php echo strtoupper(substr($balance['username'], 0, 1)); ?>
                                     </div>
                                     <div>
@@ -167,7 +101,7 @@
                                         <div class="text-sm text-gray-500">@<?php echo htmlspecialchars($balance['username']); ?></div>
                                     </div>
                                 </div>
-                                <span class="bg-green-100 text-green-700 px-3 py-1 rounded-full font-medium">
+                                <span class="bg-green-100 text-green-700 px-3 py-1 rounded-full text-xs font-semibold">
                                     <?php echo number_format($balance['amount_owed'], 2); ?> €
                                 </span>
                             </div>
@@ -178,10 +112,10 @@
             </div>
 
             <!-- People I owe -->
-            <div class="modern-card">
-                <div class="gradient-danger text-white p-4 rounded-t-2xl flex justify-between items-center">
-                    <h3 class="font-bold">People You Owe</h3>
-                    <span class="bg-white text-red-600 px-3 py-1 rounded-full text-sm font-medium">
+            <div class="bg-white shadow-md rounded-lg">
+                <div class="p-4 border-b border-gray-200 flex justify-between items-center">
+                    <h3 class="text-lg font-semibold text-gray-700">People You Owe</h3>
+                    <span class="bg-red-100 text-red-700 px-3 py-1 rounded-full text-xs font-semibold">
                         <?php echo count($balances['user_owes']); ?> people
                     </span>
                 </div>
@@ -194,9 +128,9 @@
                     <?php else: ?>
                         <div class="space-y-3">
                             <?php foreach ($balances['user_owes'] as $balance): ?>
-                            <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
+                            <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100">
                                 <div class="flex items-center">
-                                    <div class="w-10 h-10 bg-red-600 text-white rounded-full flex items-center justify-center font-semibold mr-3">
+                                    <div class="w-10 h-10 bg-slate-200 text-slate-600 rounded-full flex items-center justify-center font-semibold mr-3">
                                         <?php echo strtoupper(substr($balance['username'], 0, 1)); ?>
                                     </div>
                                     <div>
@@ -204,7 +138,7 @@
                                         <div class="text-sm text-gray-500">@<?php echo htmlspecialchars($balance['username']); ?></div>
                                     </div>
                                 </div>
-                                <span class="bg-red-100 text-red-700 px-3 py-1 rounded-full font-medium">
+                                <span class="bg-red-100 text-red-700 px-3 py-1 rounded-full text-xs font-semibold">
                                     <?php echo number_format($balance['amount_owed'], 2); ?> €
                                 </span>
                             </div>
@@ -216,10 +150,10 @@
         </div>
 
         <!-- Recent Expenses -->
-        <div class="modern-card">
-            <div class="gradient-primary text-white p-4 rounded-t-2xl flex justify-between items-center">
-                <h3 class="font-bold">Recent Expenses</h3>
-                <span class="bg-white text-indigo-600 px-3 py-1 rounded-full text-sm font-medium">
+        <div class="bg-white shadow-md rounded-lg">
+            <div class="p-4 border-b border-gray-200 flex justify-between items-center">
+                <h3 class="text-lg font-semibold text-gray-700">Recent Expenses</h3>
+                <span class="bg-blue-100 text-blue-700 px-3 py-1 rounded-full text-xs font-semibold">
                     <?php echo count($recentExpenses); ?> expenses
                 </span>
             </div>
@@ -228,7 +162,7 @@
                     <div class="text-center py-12">
                         <i class="fas fa-receipt text-6xl text-gray-300 mb-4"></i>
                         <p class="text-gray-500 mb-4">No expenses recorded yet.</p>
-                        <a href="havetopay_add.php" class="btn-modern bg-indigo-600 text-white hover:bg-indigo-700">
+                        <a href="havetopay_add.php" class="bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded-lg shadow-sm inline-flex items-center">
                             <i class="fas fa-plus mr-2"></i>Add Your First Expense
                         </a>
                     </div>
@@ -237,48 +171,48 @@
                         <table class="w-full">
                             <thead class="border-b border-gray-200">
                                 <tr>
-                                    <th class="text-left py-3 font-medium text-gray-600">Expense</th>
-                                    <th class="text-left py-3 font-medium text-gray-600">Amount</th>
-                                    <th class="text-left py-3 font-medium text-gray-600">Paid By</th>
-                                    <th class="text-left py-3 font-medium text-gray-600">Date</th>
-                                    <th class="text-left py-3 font-medium text-gray-600">Participants</th>
-                                    <th class="text-left py-3 font-medium text-gray-600">Actions</th>
+                                    <th class="text-left py-3 px-4 font-medium text-gray-600 text-sm">Expense</th>
+                                    <th class="text-left py-3 px-4 font-medium text-gray-600 text-sm">Amount</th>
+                                    <th class="text-left py-3 px-4 font-medium text-gray-600 text-sm">Paid By</th>
+                                    <th class="text-left py-3 px-4 font-medium text-gray-600 text-sm">Date</th>
+                                    <th class="text-left py-3 px-4 font-medium text-gray-600 text-sm">Participants</th>
+                                    <th class="text-left py-3 px-4 font-medium text-gray-600 text-sm">Actions</th>
                                 </tr>
                             </thead>
                             <tbody class="divide-y divide-gray-100">
                                 <?php foreach ($recentExpenses as $expense): ?>
                                 <tr class="hover:bg-gray-50">
-                                    <td class="py-4">
-                                        <div class="font-medium"><?php echo htmlspecialchars($expense['title']); ?></div>
+                                    <td class="py-4 px-4 text-sm">
+                                        <div class="font-medium text-gray-800"><?php echo htmlspecialchars($expense['title']); ?></div>
                                         <?php if(!empty($expense['description'])): ?>
-                                            <div class="text-sm text-gray-500"><?php echo htmlspecialchars(mb_strimwidth($expense['description'], 0, 50, "...")); ?></div>
+                                            <div class="text-xs text-gray-500"><?php echo htmlspecialchars(mb_strimwidth($expense['description'], 0, 50, "...")); ?></div>
                                         <?php endif; ?>
                                     </td>
-                                    <td class="py-4 font-semibold"><?php echo number_format($expense['amount'], 2); ?> €</td>
-                                    <td class="py-4">
+                                    <td class="py-4 px-4 text-sm font-semibold text-gray-700"><?php echo number_format($expense['amount'], 2); ?> €</td>
+                                    <td class="py-4 px-4 text-sm">
                                         <div class="flex items-center">
-                                            <div class="w-7 h-7 bg-indigo-600 text-white rounded-full flex items-center justify-center text-xs font-medium mr-2">
+                                            <div class="w-7 h-7 bg-slate-200 text-slate-600 rounded-full flex items-center justify-center text-xs font-medium mr-2">
                                                 <?php echo strtoupper(substr($expense['payer_name'], 0, 1)); ?>
                                             </div>
-                                            <span class="text-sm"><?php echo htmlspecialchars($expense['payer_display_name']); ?></span>
+                                            <span class="text-gray-700"><?php echo htmlspecialchars($expense['payer_display_name']); ?></span>
                                         </div>
                                     </td>
-                                    <td class="py-4 text-sm text-gray-600"><?php echo date('d M Y', strtotime($expense['expense_date'])); ?></td>
-                                    <td class="py-4">
-                                        <span class="bg-blue-100 text-blue-700 px-2 py-1 rounded-full text-xs font-medium">
+                                    <td class="py-4 px-4 text-sm text-gray-600"><?php echo date('d M Y', strtotime($expense['expense_date'])); ?></td>
+                                    <td class="py-4 px-4 text-sm">
+                                        <span class="bg-blue-100 text-blue-700 px-2 py-1 rounded-full text-xs font-semibold">
                                             <i class="fas fa-users mr-1"></i> 
                                             <?php echo $expense['participant_count']; ?> people
                                         </span>
                                     </td>
-                                    <td class="py-4">
-                                        <div class="flex gap-2">
+                                    <td class="py-4 px-4 text-sm">
+                                        <div class="flex gap-3">
                                             <a href="havetopay_detail.php?id=<?php echo $expense['id']; ?>" 
-                                               class="text-indigo-600 hover:text-indigo-800 font-medium text-sm">
+                                               class="text-blue-500 hover:text-blue-700 font-medium">
                                                 <i class="fas fa-eye mr-1"></i>Details
                                             </a>
                                             <?php if ($expense['payer_id'] == $userId || ($_SESSION['is_admin'] ?? false)): ?>
                                                 <button type="button" 
-                                                        class="text-red-600 hover:text-red-800 font-medium text-sm border-none bg-transparent cursor-pointer"
+                                                        class="text-red-500 hover:text-red-700 font-medium"
                                                         onclick="confirmDelete(<?php echo $expense['id']; ?>, '<?php echo htmlspecialchars($expense['title'], ENT_QUOTES); ?>')">
                                                     <i class="fas fa-trash mr-1"></i>Delete
                                                 </button>
@@ -297,14 +231,14 @@
     
     <!-- Delete Confirmation Modal -->
     <div id="deleteModal" class="fixed inset-0 bg-black bg-opacity-50 hidden items-center justify-center z-50">
-        <div class="bg-white rounded-lg p-6 max-w-md mx-4">
+        <div class="bg-white rounded-lg p-6 max-w-md mx-4 shadow-xl">
             <div class="flex items-center mb-4">
                 <i class="fas fa-exclamation-triangle text-red-500 text-2xl mr-3"></i>
-                <h3 class="text-lg font-semibold">Confirm Delete</h3>
+                <h3 class="text-lg font-semibold text-gray-800">Confirm Delete</h3>
             </div>
             <p class="text-gray-600 mb-6">Are you sure you want to delete "<span id="expenseTitle" class="font-medium"></span>"? This action cannot be undone.</p>
             <div class="flex justify-end gap-3">
-                <button type="button" onclick="closeDeleteModal()" class="px-4 py-2 text-gray-600 bg-gray-200 rounded-lg hover:bg-gray-300">
+                <button type="button" onclick="closeDeleteModal()" class="px-4 py-2 text-gray-700 bg-gray-200 rounded-lg hover:bg-gray-300">
                     Cancel
                 </button>
                 <form method="POST" style="display: inline;">

--- a/templates/widgets/havetopay_widget.php
+++ b/templates/widgets/havetopay_widget.php
@@ -12,7 +12,7 @@ $widgetNetBalance = $widgetNetBalance ?? 0.00;
                 <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
             </svg>
         </a>
-        <a href="havetopay_add.php" title="Add Expense" class="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold px-3 py-1.5 rounded-lg shadow-sm flex items-center text-sm">
+        <a href="havetopay_add.php" title="Add Expense" class="bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium px-3 py-1.5 rounded-lg shadow-sm flex items-center text-sm">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-1" viewBox="0 0 20 20" fill="currentColor">
                 <path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd" />
             </svg>
@@ -42,6 +42,4 @@ $widgetNetBalance = $widgetNetBalance ?? 0.00;
         </p>
     </div>
 
-    <!-- The "+" button is placed at the top-right for better visibility and consistency with potential other widgets -->
-    <!-- If a different placement is preferred, it can be moved. -->
 </article>


### PR DESCRIPTION
This commit introduces several UI improvements based on your feedback:

1.  **Dashboard Widget Position**:
    *   The HaveToPay widget on the main dashboard has been moved to the end of the widget grid for better visual flow, intending a bottom-left placement.

2.  **Dashboard Widget Design**:
    *   The "Add Expense" button within the HaveToPay dashboard widget has been restyled to be more subtle (using gray tones) for a cleaner look.

3.  **Main HaveToPay Page Redesign (`templates/havetopay.php`)**:
    *   Complete visual overhaul to achieve a simpler, lighter, and more functional design.
    *   Removed custom CSS, gradients, and heavy card styling.
    *   Replaced with standard Tailwind CSS utility classes for cards (white background, subtle shadows, bordered headers).
    *   Button styles have been standardized.
    *   Avatars now use neutral background colors.
    *   The overall page aesthetic is significantly cleaner while retaining all original functionality.