### PR TITLE
Fix sidebar layout and expand navigation

### DIFF
--- a/templates/havetopay.php
+++ b/templates/havetopay.php
@@ -7,9 +7,10 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
 </head>
-<body class="bg-gray-50 min-h-screen">
+<body class="bg-gray-50 min-h-screen flex">
     <?php include_once __DIR__ . '/navbar.php'; ?>
-    
+
+    <main class="ml-0 mt-14 md:ml-64 md:mt-0 flex-1 p-4 md:p-8">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
         <!-- Success/Error Messages -->
         <?php if (!empty($successMessage)): ?>
@@ -286,5 +287,7 @@
             }
         });
     </script>
+    </div>
+    </main>
 </body>
 </html>

--- a/templates/havetopay_add.php
+++ b/templates/havetopay_add.php
@@ -7,9 +7,10 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
 </head>
-<body class="bg-gray-50 min-h-screen">
+<body class="bg-gray-50 min-h-screen flex">
     <?php include_once __DIR__ . '/navbar.php'; ?>
-    
+
+    <main class="ml-0 mt-14 md:ml-64 md:mt-0 flex-1 p-4 md:p-8">
     <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
         <!-- Back Link -->
         <div class="mb-8">
@@ -156,5 +157,6 @@
             </div>
         </div>
     </div>
+    </main>
 </body>
 </html>

--- a/templates/havetopay_detail.php
+++ b/templates/havetopay_detail.php
@@ -7,9 +7,10 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
 </head>
-<body class="bg-gray-50 min-h-screen">
+<body class="bg-gray-50 min-h-screen flex">
     <?php include_once __DIR__ . '/navbar.php'; ?>
-    
+
+    <main class="ml-0 mt-14 md:ml-64 md:mt-0 flex-1 p-4 md:p-8">
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
         <!-- Back Link -->
         <div class="mb-8">
@@ -307,5 +308,7 @@
             }
         });
     </script>
+    </div>
+    </main>
 </body>
 </html>

--- a/templates/navbar.php
+++ b/templates/navbar.php
@@ -454,6 +454,32 @@ $isHaveToPayPage = basename($_SERVER['PHP_SELF']) === 'havetopay.php' ||
             <span>Kalender</span>
           </a>
         </li>
+        <li>
+          <a href="/taskboard.php" class="flex items-center space-x-3 px-3 py-2 rounded-lg hover:bg-gray-100">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+            <span>Taskboard</span>
+          </a>
+        </li>
+        <li>
+          <a href="/havetopay.php" class="flex items-center space-x-3 px-3 py-2 rounded-lg hover:bg-gray-100">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8V4m0 12v4" />
+            </svg>
+            <span>HaveToPay</span>
+          </a>
+        </li>
+        <?php if ($user && ($user['role'] ?? '') === 'admin'): ?>
+        <li>
+          <a href="/admin.php" class="flex items-center space-x-3 px-3 py-2 rounded-lg hover:bg-gray-100">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 11c-1.657 0-3-1.343-3-3s1.343-3 3-3 3 1.343 3 3-1.343 3-3 3zm0 2c-2.21 0-4 1.79-4 4v1h8v-1c0-2.21-1.79-4-4-4z" />
+            </svg>
+            <span>Admin</span>
+          </a>
+        </li>
+        <?php endif; ?>
         <!-- More menu items can be added here -->
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- keep the purple gradient sidebar but add missing links for Taskboard, HaveToPay and an Admin section
- wrap HaveToPay pages in a `<main>` container so content sits beside the sidebar

## Testing
- `php` command not available, so no syntax check run

------
https://chatgpt.com/codex/tasks/task_e_6848085636f08330aef3aa13d39ce8e1