### PR TITLE
Improve calendar dashboard widget

### DIFF
--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -909,40 +909,48 @@
 
       <!-- Calendar Short -->
       <div class="dashboard-short">
-        <div class="short-header p-6" onclick="window.location.href='calendar.php'">
+        <div class="short-header p-6" onclick="window.location.href='calendar.php?view=week'">
           <div class="flex items-center justify-between">
             <h3 class="text-white font-semibold text-xl">Kalender</h3>
             <div class="text-right">
-              <div class="stats-number text-3xl"><?= count($upcomingEvents ?? []) ?></div>
+              <div class="stats-number text-3xl"><?= count($todayEvents ?? []) ?></div>
               <div class="text-white/60 text-sm">heute</div>
             </div>
           </div>
         </div>
-        
+
         <div class="p-6">
-          <div class="short-scroll space-y-3">
-            <?php if (!empty($upcomingEvents)): ?>
-              <?php foreach(array_slice($upcomingEvents, 0, 4) as $event): ?>
-                <div class="short-list-item p-4" onclick="window.location.href='calendar.php'">
-                  <div class="flex justify-between items-start mb-2">
-                    <h4 class="text-white font-medium text-sm truncate flex-1"><?= htmlspecialchars($event['title']) ?></h4>
-                    <span class="text-blue-400 text-xs ml-2"><?= date('H:i', strtotime($event['event_date'])) ?></span>
-                  </div>
-                  <?php if(!empty($event['description'])): ?>
-                    <p class="text-white/60 text-xs truncate"><?= htmlspecialchars($event['description']) ?></p>
-                  <?php endif; ?>
-                  <div class="text-xs text-white/50 mt-2">
-                    <span><?= date('d.m.Y', strtotime($event['event_date'])) ?></span>
-                  </div>
+          <div class="short-scroll space-y-2">
+            <?php
+              $weekStart = new DateTimeImmutable('monday this week');
+              for ($i = 0; $i < 7; $i++):
+                $day = $weekStart->modify("+{$i} days");
+                $isToday = $day->format('Y-m-d') === date('Y-m-d');
+                $dayEvents = $eventsByDate[$day->format('Y-m-d')] ?? [];
+            ?>
+              <div class="short-list-item p-3 <?= $isToday ? 'bg-purple-600/30' : '' ?>" onclick="window.location.href='calendar.php?view=day&year=<?= $day->format('Y') ?>&month=<?= $day->format('m') ?>&day=<?= $day->format('d') ?>'">
+                <div class="flex justify-between items-center">
+                  <span class="text-white text-sm font-medium">
+                    <?= $day->format('D d.m') ?>
+                  </span>
+                  <span class="text-white/60 text-xs"><?= count($dayEvents) ?></span>
                 </div>
-              <?php endforeach; ?>
-            <?php else: ?>
-              <div class="text-center py-6">
-                <p class="text-white/60 text-sm">Keine Termine geplant</p>
+                <?php foreach(array_slice($dayEvents, 0, 2) as $event): ?>
+                  <div class="flex justify-between text-xs text-white/80 mt-1">
+                    <span class="truncate flex-1">
+                      <?= htmlspecialchars($event['title']) ?>
+                    </span>
+                    <?php if (!empty($event['start_time'])): ?>
+                      <span class="text-blue-400 ml-2">
+                        <?= substr($event['start_time'], 0, 5) ?>
+                      </span>
+                    <?php endif; ?>
+                  </div>
+                <?php endforeach; ?>
               </div>
-            <?php endif; ?>
+            <?php endfor; ?>
           </div>
-          
+
           <div class="mt-6">
             <button onclick="window.location.href='calendar.php'" class="quick-action-btn w-full px-4 py-2">
               Neuer Termin
@@ -1129,10 +1137,10 @@
           
           <div class="flex justify-between items-center">
             <span class="text-white/80 text-sm">Termine</span>
-            <span class="text-white font-semibold"><?= count($upcomingEvents ?? []) ?></span>
+            <span class="text-white font-semibold"><?= $totalWeekEvents ?></span>
           </div>
           <div class="progress-bar">
-            <div class="progress-fill bg-gradient-to-r from-purple-500 to-purple-400" style="width: <?= min(100, count($upcomingEvents ?? []) * 20) ?>%"></div>
+            <div class="progress-fill bg-gradient-to-r from-purple-500 to-purple-400" style="width: <?= min(100, $totalWeekEvents * 20) ?>%"></div>
           </div>
           
           <div class="mt-6">

--- a/templates/widgets/calendar_widget.php
+++ b/templates/widgets/calendar_widget.php
@@ -3,18 +3,38 @@ require_once __DIR__.'/../../src/lib/auth.php';
 requireLogin();
 require_once __DIR__.'/../../src/lib/db.php';
 
-// Fetch upcoming events for the current user
-$stmt = $pdo->prepare("
-    SELECT e.*, u.username AS creator_name
-    FROM events e
-    LEFT JOIN users u ON u.id = e.created_by
-    WHERE (e.assigned_to = ? OR e.created_by = ?)
-    AND e.event_date >= CURDATE()
-    ORDER BY e.event_date ASC
-    LIMIT 5
-");
-$stmt->execute([$user['id'], $user['id']]);
-$upcomingEvents = $stmt->fetchAll(PDO::FETCH_ASSOC);
+// Fetch events for the current week for the widget
+$today = new DateTimeImmutable('today');
+$dayOfWeek = (int)$today->format('N');
+$startOfWeek = $today->modify('-' . ($dayOfWeek - 1) . ' days');
+$endOfWeek = $startOfWeek->modify('+6 days');
+
+$stmt = $pdo->prepare(
+    "SELECT e.*, u.username AS creator_name
+     FROM events e
+     LEFT JOIN users u ON u.id = e.created_by
+     WHERE (e.assigned_to = ? OR e.created_by = ?)
+       AND e.event_date BETWEEN ? AND ?
+     ORDER BY e.event_date ASC, IFNULL(e.start_time, '') ASC"
+);
+$stmt->execute([
+    $user['id'],
+    $user['id'],
+    $startOfWeek->format('Y-m-d'),
+    $endOfWeek->format('Y-m-d')
+]);
+$weeklyEvents = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+// Group events by date
+$eventsByDate = [];
+foreach ($weeklyEvents as $event) {
+    $date = $event['event_date'];
+    if (!isset($eventsByDate[$date])) {
+        $eventsByDate[$date] = [];
+    }
+    $eventsByDate[$date][] = $event;
+}
+$todayEvents = $eventsByDate[$today->format('Y-m-d')] ?? [];
 
 // Get total event count for current month
 $stmt = $pdo->prepare("
@@ -45,35 +65,35 @@ $monthlyEvents = $stmt->fetch(PDO::FETCH_ASSOC)['total'] ?? 0;
   <div class="flex justify-between items-center mb-6">
     <h2 class="text-white/90 text-xl font-semibold">Kalender</h2>
     <div class="text-right">
-      <div class="text-xs text-white/60 mb-1">Termine</div>
-      <div class="text-lg font-bold text-white/90"><?= count($upcomingEvents ?? []) ?></div>
+      <div class="text-xs text-white/60 mb-1">heute</div>
+      <div class="text-lg font-bold text-white/90"><?= count($todayEvents) ?></div>
     </div>
   </div>
 
   <div class="widget-scroll-container flex-1">
     <div id="dashboardEventList" class="widget-scroll-content space-y-2">
-      <?php if (!empty($upcomingEvents)): ?>
-        <?php foreach ($upcomingEvents as $event): ?>
-          <div class="widget-list-item p-3 bg-white/5 border border-white/10 rounded-lg transition-all duration-300 hover:bg-white/10 hover:border-white/20 hover:transform hover:translateX-1 cursor-pointer" onclick="window.location.href='calendar.php'">
-            <div class="flex justify-between items-start">
-              <div class="flex-1 min-w-0">
-                <div class="task-title text-sm truncate text-white/90">
-                  <?= htmlspecialchars($event['title']) ?>
-                </div>
-                <?php if (!empty($event['description'])): ?>
-                  <div class="task-description text-xs truncate text-white/60">
-                    <?= htmlspecialchars($event['description']) ?>
-                  </div>
-                <?php endif; ?>
-              </div>
-            </div>
+      <?php
+        $weekStart = new DateTimeImmutable('monday this week');
+        for ($i = 0; $i < 7; $i++):
+          $day = $weekStart->modify("+{$i} days");
+          $isToday = $day->format('Y-m-d') === date('Y-m-d');
+          $dayEvents = $eventsByDate[$day->format('Y-m-d')] ?? [];
+      ?>
+        <div class="widget-list-item p-3 bg-white/5 border border-white/10 rounded-lg transition-all duration-300 hover:bg-white/10 hover:border-white/20 hover:transform hover:translateX-1 cursor-pointer <?= $isToday ? 'bg-purple-600/30' : '' ?>" onclick="window.location.href='calendar.php?view=day&year=<?= $day->format('Y') ?>&month=<?= $day->format('m') ?>&day=<?= $day->format('d') ?>'">
+          <div class="flex justify-between items-center">
+            <span class="text-sm text-white font-medium"><?= $day->format('D d.m') ?></span>
+            <span class="text-xs text-white/60"><?= count($dayEvents) ?></span>
           </div>
-        <?php endforeach; ?>
-      <?php else: ?>
-        <div class="text-center py-6">
-          <div class="text-white/40 text-sm">Keine Termine</div>
+          <?php foreach(array_slice($dayEvents, 0, 2) as $event): ?>
+            <div class="flex justify-between text-xs text-white/80 mt-1">
+              <span class="truncate flex-1"><?= htmlspecialchars($event['title']) ?></span>
+              <?php if (!empty($event['start_time'])): ?>
+                <span class="text-blue-400 ml-2"><?= substr($event['start_time'],0,5) ?></span>
+              <?php endif; ?>
+            </div>
+          <?php endforeach; ?>
         </div>
-      <?php endif; ?>
+      <?php endfor; ?>
     </div>
   </div>
 </article>


### PR DESCRIPTION
## Summary
- modify dashboard controller to fetch weekly events
- display weekly agenda in calendar widget
- update statistics widget to use weekly events
- adjust standalone calendar widget for weekly view

## Testing
- `php -l src/controllers/dashboard.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c66a7b3a08330a459486288c581e6